### PR TITLE
defined Song invariants

### DIFF
--- a/core/src/main/java/com/bobo/storage/core/domain/Provider.java
+++ b/core/src/main/java/com/bobo/storage/core/domain/Provider.java
@@ -66,21 +66,14 @@ public enum Provider {
 
   /**
    * Looks up metadata for a Song, if data is found the Song will be mutated with the information found.
-   * It is the caller's responsibility to handle {@link Song#setLastLookup(LocalDateTime)}.
    *
    * @return true if information about the Song was found.
    */
   public static boolean lookupSong(Song song, WebClient webClient) {
-    URL url;
-    try {
-      url = URI.create(song.getUrl()).toURL();
-    } catch (MalformedURLException e) {
-      // TODO [design] the Song URL may be stored as a String, but it should probably be typed to a URL.
-      throw new RuntimeException("The URL of the Song was invalid.");
-    }
-
+    URL url = song.toUrl();
     for (Provider provider : values()) {
       Optional<OEmbedResponse> metadata = provider.queryProvider(url, webClient);
+      song.lookedUp();  // TODO [design] Should this be repeated anytime we lookup the Song, or done once at the root?
       if (metadata.isPresent()) {
         metadata.get().accept(song);
         return true;

--- a/core/src/main/java/com/bobo/storage/core/service/SongLookupService.java
+++ b/core/src/main/java/com/bobo/storage/core/service/SongLookupService.java
@@ -31,7 +31,7 @@ public interface SongLookupService {
    * </ol>
    *
    * @param song to lookup.
-   * @see Song#verifyUrl(WebClient)
+   * @see Song#verify(WebClient)
    * @see Provider#lookupSong(Song, WebClient)
    */
   void lookup(Song song);

--- a/core/src/main/java/com/bobo/storage/core/service/impl/SongLookupServiceImpl.java
+++ b/core/src/main/java/com/bobo/storage/core/service/impl/SongLookupServiceImpl.java
@@ -44,7 +44,7 @@ public class SongLookupServiceImpl implements SongLookupService {
    */
   @Transactional
   public void lookup(Song song) {
-    if (song.verifyUrl(webClient)) {
+    if (song.verify(webClient)) {
       Optional<Song> existingSong = songs.findByUrl(song.getUrl());
       if (existingSong.isPresent() && !existingSong.get().getId().equals(song.getId())) {
         log.info("Lookup#Redirection: Song(id:{}) Redirects to existing Song(id:{}), will migrate to existing Song.",
@@ -61,7 +61,6 @@ public class SongLookupServiceImpl implements SongLookupService {
     }
 
     Provider.lookupSong(song, webClient); // TODO [design] Returns Optional<Provider> for later co-ordination?
-    song.setLastLookup(LocalDateTime.now());
     songService.updateSong(song);
   }
 

--- a/core/src/test/java/com/bobo/storage/core/domain/PlaylistSongTest.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/PlaylistSongTest.java
@@ -29,7 +29,7 @@ class PlaylistSongTest {
     @DisplayName("A PlaylistSong can be constructed from valid arguments")
     void canBeConstructed() {
       Playlist playlist = new PlaylistMother(random).withAll().get();
-      Song song = new SongMother(random).withAll().get();
+      Song song = new SongMother(random).withIds().get();
 
       PlaylistSong playlistSong = Assertions.assertDoesNotThrow(() -> new PlaylistSong(playlist, song));
       Assertions.assertSame(playlist, playlistSong.getPlaylist());
@@ -40,7 +40,7 @@ class PlaylistSongTest {
     @DisplayName("Playlist argument must have an assigned TechnicalId")
     void unassignedPlaylist() {
       Playlist playlist = new PlaylistMother(random).withIds(() -> null).get();
-      Song song = new SongMother(random).withAll().get();
+      Song song = new SongMother(random).withIds().get();
 
       Assertions.assertThrows(IllegalArgumentException.class, () -> new PlaylistSong(playlist, song));
     }
@@ -62,7 +62,7 @@ class PlaylistSongTest {
     @DisplayName("Playlist and Song must exist")
     void missingArguments() {
       Playlist playlist = new PlaylistMother(random).withAll().get();
-      Song song = new SongMother(random).withAll().get();
+      Song song = new SongMother(random).withIds().get();
 
       Assertions.assertThrows(NullPointerException.class,
                               () -> new PlaylistSong(null, song),

--- a/core/src/test/java/com/bobo/storage/core/domain/SongIT.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/SongIT.java
@@ -23,14 +23,14 @@ class SongIT {
   }
 
   /**
-   * @see Song#verifyUrl(WebClient)
+   * @see Song#verify(WebClient)
    */
   @DisplayName("Verifying a URL that requests a client to redirect (status code 3xx) should update the Song's url to use the target location.")
   @ParameterizedTest
   @MethodSource("redirectingUrls")
-  void verifyUrl(RedirectingURL redirectingUrl) {
+  void verify(RedirectingURL redirectingUrl) {
     Song song = new Song(redirectingUrl.url);
-    song.verifyUrl(client);
+    song.verify(client);
     // TODO Consider doing a test assumption that the URL exists, and is a redirection. See #redirectingUrl docs.
     Assertions.assertEquals(redirectingUrl.targetLocation(), song.getUrl());
   }

--- a/core/src/test/java/com/bobo/storage/core/domain/SongMother.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/SongMother.java
@@ -1,13 +1,11 @@
 package com.bobo.storage.core.domain;
 
+import java.time.LocalDateTime;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Random;
 import java.util.function.Supplier;
 
-/**
- * TODO There are now additional {@code Song} fields the {@code Mother} needs to produce,
- *  but as I am not sure about which fields will stay, I am not going to create them as yet.
- */
 public class SongMother implements EntityMother<Song> {
 
   private final Random random;
@@ -15,6 +13,14 @@ public class SongMother implements EntityMother<Song> {
   private Supplier<Integer> ids;
 
   private Supplier<String> urls;
+
+  private Supplier<LocalDateTime> lastLookups;
+
+  private Supplier<String> titles;
+
+  private Supplier<String> artists;
+
+  private Supplier<String> thumbnailUrls;
 
   /**
    * Unless otherwise configured, a {@code SongMother} uses randomness to generate mock data.
@@ -33,7 +39,7 @@ public class SongMother implements EntityMother<Song> {
 
   /**
    * While the default constructor is always provided,
-   * prefer {@link SongMother#SongMother(Random)}  SongMother} where possible.
+   * prefer {@link SongMother#SongMother(Random)} where possible.
    */
   @SuppressWarnings("unused")
   public SongMother() {
@@ -45,17 +51,26 @@ public class SongMother implements EntityMother<Song> {
     Song song = new Song();
 
     Integer id = Objects.isNull(ids) ? null : ids.get();
-    String url = Objects.isNull(urls) ? "" : urls.get();
+    assert urls != null;
+    String url = urls.get();
+    LocalDateTime lastLookup = Objects.isNull(lastLookups) ? null : lastLookups.get();
+    String title = Objects.isNull(titles) ? null : titles.get();
+    String artist = Objects.isNull(artists) ? null : artists.get();
+    String thumbnailUrl = Objects.isNull(thumbnailUrls) ? null : thumbnailUrls.get();
 
     song.setId(id);
     song.setUrl(url);
+    song.setLastLookup(lastLookup);
+    song.setTitle(title);
+    song.setArtist(artist);
+    song.setThumbnailUrl(thumbnailUrl);
 
     return song;
   }
 
   @Override
   public SongMother withAll() {
-    return this.withIds().withUrls();
+    return this.withIds().withUrls().withLastLookups().withTitles().withArtists().withThumbnailUrls();
   }
 
   @Override
@@ -75,12 +90,51 @@ public class SongMother implements EntityMother<Song> {
   }
 
   public SongMother withUrls(Supplier<String> urls) {
+    Objects.requireNonNull(urls, """
+            The Supplier of a required field in a Mother class can never be null.
+            Invoke #withUrls if you need to reset a previous #withUrl(Supplier) configuration.""");
     this.urls = urls;
     return this;
   }
 
   public SongMother withUrls() {
-    return this.withUrls(() -> Long.toString(random.nextLong()));
+    return this.withUrls(() -> String.format(Locale.ROOT, "https://mock-%d.test", random.nextLong()));
+  }
+
+  public SongMother withLastLookups(Supplier<LocalDateTime> lastLookups) {
+    this.lastLookups = lastLookups;
+    return this;
+  }
+
+  public SongMother withLastLookups() {
+    return withLastLookups(() -> LocalDateTime.now().minusSeconds(Math.abs(random.nextLong())));
+  }
+
+  public SongMother withTitles(Supplier<String> titles) {
+    this.titles = titles;
+    return this;
+  }
+
+  public SongMother withTitles() {
+    return withTitles(() -> Long.toString(this.random.nextLong()));
+  }
+
+  public SongMother withArtists(Supplier<String> artists) {
+    this.artists = artists;
+    return this;
+  }
+
+  public SongMother withArtists() {
+    return withArtists(() -> Long.toString(this.random.nextLong()));
+  }
+
+  public SongMother withThumbnailUrls(Supplier<String> thumbnailUrls) {
+    this.thumbnailUrls = thumbnailUrls;
+    return this;
+  }
+
+  public SongMother withThumbnailUrls() {
+    return withThumbnailUrls(() -> String.format(Locale.ROOT, "https://mock-%d.test", random.nextLong()));
   }
 
 }

--- a/core/src/test/java/com/bobo/storage/core/domain/SongTest.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/SongTest.java
@@ -13,9 +13,9 @@ class SongTest {
   @Test
   void equality() {
     Song[] songs = new Song[3];
-    songs[0] = new Song("a");
-    songs[1] = new Song("a");
-    songs[2] = new Song("b");
+    songs[0] = new Song("https://a.com");
+    songs[1] = new Song("https://a.com");
+    songs[2] = new Song("https://b.com");
 
     Assertions.assertEquals(songs[0], songs[1]);
     Assertions.assertNotEquals(songs[1], songs[2]);
@@ -24,13 +24,13 @@ class SongTest {
   @Test
   void hashing() {
     Set<Song> songs = new HashSet<>();
-    songs.add(new Song("a"));
+    songs.add(new Song("https://a.com"));
 
-    songs.add(new Song("a"));
+    songs.add(new Song("https://a.com"));
 
     Assertions.assertEquals(1, songs.size());
 
-    songs.add(new Song("b"));
+    songs.add(new Song("https://b.com"));
     Assertions.assertEquals(2, songs.size());
   }
 

--- a/web/src/main/java/com/bobo/storage/web/api/v2/response/PlaylistSongResponse.java
+++ b/web/src/main/java/com/bobo/storage/web/api/v2/response/PlaylistSongResponse.java
@@ -7,7 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 
 /**
- * Where {@code Optional} fields are only included in the response if they have a value.
+ * {@link JsonInclude.Include#NON_ABSENT} so that {@code Optional} fields are only included in the
+ * response if they have a value.
  * <p>
  * TODO Consider defining this globally.
  */
@@ -20,9 +21,9 @@ public record PlaylistSongResponse(Integer id, String url,
   public PlaylistSongResponse(PlaylistSong playlistSong) {
     this(playlistSong.getId(),
          playlistSong.getSong().getUrl(),
-         Optional.ofNullable(playlistSong.getSong().getTitle()),
-         Optional.ofNullable(playlistSong.getSong().getArtist()),
-         Optional.ofNullable(playlistSong.getSong().getThumbnailUrl())
+         playlistSong.getSong().getTitle(),
+         playlistSong.getSong().getArtist(),
+         playlistSong.getSong().getThumbnailUrl()
     );
   }
 

--- a/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistsControllerTest.java
+++ b/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistsControllerTest.java
@@ -237,7 +237,7 @@ class PlaylistsControllerTest {
   @Test
   void deletePlaylist() throws Exception {
     // Given
-    PlaylistMother mother = new PlaylistMother(random).withAll();
+    PlaylistMother mother = new PlaylistMother(random).withIds();
     Playlist playlist = mother.get();
     Integer id = playlist.getId();
 


### PR DESCRIPTION
The `Song` class now defines and enforces its invariants, as specified by
the `domain` package requirements.

Metadata fields on Song are now accessed using `Optional`,
which better expresses their nature in the domain - there is no
guarantee that we can find metadata for a given `url`. This could not be
modelled initially due to usage of `AccessType#Property` forcing the
return type to correspond to the data type. This restriction has since
been removed, see previous logs.

[fixes]
* `#verifyUrl` not setting `lastLookup`.

[additions]
* added `#validatedUrl`. Leverages Java implementations for parsing URI
  and URLs.
* added `#toUri`, `#toUrl` that guarantee conversion to URI and URL
  respectively.
* added `#lookedUp` & marked `#setLastLookedUp` as protected (for testing).
  `#lookedUp` is all that is required for coordination. Allowing a
  caller to specify any arbitrary lookup time is inaccurate. The best
  way to express that the lookup time must be set when a lookup is
  performed is to only provide the option to set it 'now'. Needs review.

[revisions]
* mv `#verifyUrl` -> `#verify`. We do not need to specify that we are
  verifying the `url` because a `Song` is the reference. We are verifying
  the reference.
* Provider now leverages `#toUrl`, rather than taking responsibility for
  converting the Song's `url`.

[housekeeping]
* resolved `SongMother` TODO. `SongMother` now supplies metadata fields as
  expected.
* disfavoured `SongMother#withAll`. Only use it where it is necessary for
  all fields to be populated.