### PR TITLE
added DomainEntity#log signatures

### DIFF
--- a/core/src/main/java/com/bobo/storage/core/domain/DomainEntity.java
+++ b/core/src/main/java/com/bobo/storage/core/domain/DomainEntity.java
@@ -59,7 +59,9 @@ public abstract class DomainEntity implements TechnicalID<Integer> {
 	 * The {@link TechnicalID} of a {@link DomainEntity} is managed exclusively by the persistence
 	 * provider.
 	 *
-	 * <p>This mutator exists solely for internal use in testing scenarios.
+	 * <p>This mutator exists solely for internal use in testing scenarios.</p>
+	 * <p>Should be marked {@code final}, but the JPA provider (Hibernate) proxies the setters for lazy-loading
+	 * operations.</p>
 	 *
 	 * @param id the technical identifier to assign to this {@link Entity}
 	 * @see TechnicalID#getId()
@@ -75,7 +77,7 @@ public abstract class DomainEntity implements TechnicalID<Integer> {
 	 *     accessors for lazy-loading operations.
 	 */
 	@Override
-	public Integer getId() {
+	public final Integer getId() {
 		return id;
 	}
 }

--- a/core/src/main/java/com/bobo/storage/core/domain/Song.java
+++ b/core/src/main/java/com/bobo/storage/core/domain/Song.java
@@ -116,10 +116,10 @@ public class Song extends DomainEntity {
 					"""
 																							The URL of a Song is guaranteed to be a valid URL,\s
 																							but it failed to be parsed into one.\s
-																							Was this entity (id:%d) created directly into the database,
+																							Was this %s created directly into the database,
 																							circumventing application logic,\s
 																							or has the application logic failed to guarantee the invariant?"""
-							.formatted(this.getId()),
+							.formatted(this.log()),
 					e);
 		}
 	}
@@ -137,10 +137,10 @@ public class Song extends DomainEntity {
 					"""
 																							The URL of a Song is guaranteed to be a valid URI and URL,\s
 																							conforming to RFC 2396, but it failed to be converted back into a URI.\s
-																							Was this entity (id:%d) created directly into the database,
+																							Was this %s created directly into the database,
 																							circumventing application logic,\s
 																							or has the application logic failed to guarantee the invariant?"""
-							.formatted(this.getId()),
+							.formatted(this.log()),
 					e);
 		}
 	}

--- a/core/src/main/java/com/bobo/storage/core/service/SongLookupService.java
+++ b/core/src/main/java/com/bobo/storage/core/service/SongLookupService.java
@@ -34,7 +34,7 @@ public interface SongLookupService {
 	 *
 	 * @param song to lookup.
 	 * @see Song#verify(WebClient)
-	 * @see Provider#lookupSong(Song, WebClient)
+	 * @see Provider#lookup(Song, WebClient)
 	 */
 	void lookup(Song song);
 }

--- a/core/src/main/java/com/bobo/storage/core/service/impl/PlaylistSongServiceImpl.java
+++ b/core/src/main/java/com/bobo/storage/core/service/impl/PlaylistSongServiceImpl.java
@@ -1,5 +1,6 @@
 package com.bobo.storage.core.service.impl;
 
+import com.bobo.storage.core.domain.DomainEntity;
 import com.bobo.storage.core.domain.PlaylistSong;
 import com.bobo.storage.core.domain.Song;
 import com.bobo.storage.core.resource.access.PlaylistSongRepository;
@@ -7,11 +8,15 @@ import com.bobo.storage.core.resource.query.PlaylistSongQueryRepository;
 import com.bobo.storage.core.service.PlaylistSongService;
 import java.util.Collection;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PlaylistSongServiceImpl implements PlaylistSongService {
+
+	private static final Logger log = LoggerFactory.getLogger(PlaylistSongServiceImpl.class);
 
 	private final PlaylistSongRepository repository;
 
@@ -43,5 +48,10 @@ public class PlaylistSongServiceImpl implements PlaylistSongService {
 		Collection<PlaylistSong> songsToTransfer = query.findAllBySong(from);
 		songsToTransfer.forEach(song -> song.migrate(to));
 		repository.saveAll(songsToTransfer);
+		log.info(
+				"PlaylistSong#Migration: {} migrated from {} to {}.",
+				DomainEntity.log(songsToTransfer),
+				from.log(),
+				to.log());
 	}
 }

--- a/core/src/main/java/com/bobo/storage/core/service/impl/SongLookupServiceImpl.java
+++ b/core/src/main/java/com/bobo/storage/core/service/impl/SongLookupServiceImpl.java
@@ -51,22 +51,20 @@ public class SongLookupServiceImpl implements SongLookupService {
 			Optional<Song> existingSong = songs.findByUrl(song.getUrl());
 			if (existingSong.isPresent() && !TechnicalID.same(existingSong.get(), song)) {
 				log.info(
-						"Lookup#Redirection: Song(id:{}) Redirects to existing Song(id:{}), will migrate to existing Song.",
-						song.getId(),
-						existingSong.get().getId());
+						"Lookup: {} redirects to {}. Its references will be migrated to the existing Song, and it will be removed.",
+						song.log(),
+						existingSong.get().log());
 				playlistSongService.migrate(song, existingSong.get());
 				songService.delete(song);
 			} else {
-				log.debug(
-						"Lookup#Redirection: Song(id:{}) redirects. URL updated. Lookup deferred.",
-						song.getId());
+				log.debug("Lookup: {} redirects. URL updated. Lookup deferred.", song.log());
 				songService.updateSong(song);
 			}
 			return;
 		}
 
-		Provider.lookupSong(
-				song, webClient); // TODO [design] Returns Optional<Provider> for later co-ordination?
+		// TODO [design] Returns Optional<Provider> for later co-ordination?
+		Provider.lookup(song, webClient);
 		songService.updateSong(song);
 	}
 }

--- a/core/src/test/java/com/bobo/storage/core/domain/DomainEntityTest.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/DomainEntityTest.java
@@ -1,0 +1,79 @@
+package com.bobo.storage.core.domain;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DomainEntityTest {
+
+	/**
+	 * To be used for creating arbitrary values that will <b>never</b> change during the scope of the
+	 * test they were created within.
+	 *
+	 * <p>Mark such values {@code final} where possible to declare the intention.
+	 */
+	private final Random random = new Random();
+
+	@Test
+	@DisplayName("Produces a log in the format Entity(id:...)")
+	void log() {
+		// Given
+		DomainEntity entity = new SongMother(random).withIds(() -> 1).get();
+		// When
+		String log = entity.log();
+		// Then
+		Assertions.assertEquals("Song(id:1)", log);
+	}
+
+	/**
+	 * @see DomainEntity#log(Collection)
+	 */
+	@Nested
+	class LogCollection {
+
+		@Test
+		@DisplayName("Produces a log in the format n Entity(ids:...,...)")
+		void log() {
+			// Given
+			List<Song> entities = new SongMother(random).get(3).toList();
+			EntityMother.setId(entities.get(0), 1);
+			EntityMother.setId(entities.get(1), 2);
+			EntityMother.setId(entities.get(2), 3);
+			// When
+			String log = DomainEntity.log(entities);
+			// Then
+			Assertions.assertEquals("3 Song(ids:1, 2, 3)", log);
+		}
+
+		@Test
+		@DisplayName("Throws IllegalArgumentException if the collection is empty.")
+		void empty() {
+			// Given
+			Collection<DomainEntity> entities = Collections.emptyList();
+			// When
+			Assertions.assertThrows(
+					IllegalArgumentException.class,
+					// Then
+					() -> DomainEntity.log(entities));
+		}
+
+		@Test
+		@DisplayName("Throws IllegalArgumentException if the collection is non-homogenous.")
+		void nonHomogeneous() {
+			// Given
+			Playlist playlist = new PlaylistMother(random).withIds().get();
+			Song song = new SongMother(random).withIds().get();
+			Collection<DomainEntity> entities = List.of(playlist, song);
+			// When
+			Assertions.assertThrows(
+					IllegalArgumentException.class,
+					// Then
+					() -> DomainEntity.log(entities));
+		}
+	}
+}

--- a/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
@@ -25,7 +25,7 @@ class ProviderIT {
 	}
 
 	/**
-	 * @see Provider#lookupSong(Song, WebClient)
+	 * @see Provider#lookup(Song, WebClient)
 	 */
 	@ParameterizedTest
 	@ValueSource(
@@ -37,9 +37,9 @@ class ProviderIT {
 				"https://www.deezer.com/track/350027801?host=0&utm_campaign=clipboard-generic&utm_source=user_sharing&utm_content=track-350027801&deferredFl=1&universal_link=1",
 				"https://open.spotify.com/track/6G6EAmGXX7T52zOWj2GWPE?si=145d2b7ff94641dc"
 			})
-	void lookupSong(String url) {
+	void lookup(String url) {
 		Song song = new Song(url);
-		Assertions.assertTrue(Provider.lookupSong(song, client));
+		Assertions.assertTrue(Provider.lookup(song, client));
 		// TODO [test] define a control test for each provider to ensure a link for that provider works
 		// as expected.
 		// TODO [test] see Deezer note above; create parameterized tests for each Provider for different


### PR DESCRIPTION
Leveraged these new signatures in existing logs to improve readability, whilst also ensuring brevity and consistency across logs.

[additions]
- added logging to Provider, PlaylistSongServiceImpl.

[housekeeping]
- neatened existing log messages.
- correct markups on DomainEntity docs.
- mv Provider#lookupSong #lookup. Reads better. A Provider doesn't lookup anything else. Context is given in the parameter list as well.
- marked Provider#getQuery as protected for testing. Must have been an oversight.