### PR TITLE
mark EntityRepositories package-private

### DIFF
--- a/core/src/main/java/com/bobo/storage/core/playlist/PlaylistRepository.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/PlaylistRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
  * @implSpec {@link EntityRepository}
  */
 @Repository
-public interface PlaylistRepository
+interface PlaylistRepository
 		extends EntityRepository<Playlist, Integer>, CrudRepository<Playlist, Integer> {
 
 	@NonNull <S extends Playlist> Collection<S> saveAll(@NonNull Iterable<S> entities);

--- a/core/src/main/java/com/bobo/storage/core/playlist/PlaylistService.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/PlaylistService.java
@@ -2,6 +2,7 @@ package com.bobo.storage.core.playlist;
 
 import com.bobo.storage.core.semantic.CoreService;
 import com.bobo.storage.core.semantic.Create;
+import com.bobo.storage.core.semantic.EntityService;
 import com.bobo.storage.core.semantic.Read;
 import java.util.Collection;
 import java.util.Objects;
@@ -9,7 +10,7 @@ import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 
 @CoreService
-public class PlaylistService implements Create<Playlist>, Read<Playlist> {
+public class PlaylistService implements EntityService<Playlist>, Create<Playlist>, Read<Playlist> {
 
 	private final PlaylistRepository playlists;
 

--- a/core/src/main/java/com/bobo/storage/core/playlist/PlaylistService.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/PlaylistService.java
@@ -13,7 +13,7 @@ public class PlaylistService implements Create<Playlist>, Read<Playlist> {
 
 	private final PlaylistRepository playlists;
 
-	public PlaylistService(PlaylistRepository playlistRepository) {
+	PlaylistService(PlaylistRepository playlistRepository) {
 		this.playlists = playlistRepository;
 	}
 

--- a/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongRepository.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
  * @implSpec {@link EntityRepository}
  */
 @Repository
-public interface PlaylistSongRepository
+interface PlaylistSongRepository
 		extends EntityRepository<PlaylistSong, Integer>, CrudRepository<PlaylistSong, Integer> {
 
 	Collection<PlaylistSong> findAllByPlaylist(Playlist playlist);

--- a/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongService.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongService.java
@@ -23,7 +23,7 @@ public class PlaylistSongService implements Create<PlaylistSong>, Read<PlaylistS
 
 	private final SongService songs;
 
-	public PlaylistSongService(PlaylistSongRepository playlistSongs, SongService songs) {
+	PlaylistSongService(PlaylistSongRepository playlistSongs, SongService songs) {
 		this.playlistSongs = playlistSongs;
 		this.songs = songs;
 	}

--- a/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongService.java
+++ b/core/src/main/java/com/bobo/storage/core/playlist/song/PlaylistSongService.java
@@ -4,6 +4,7 @@ import com.bobo.storage.core.playlist.Playlist;
 import com.bobo.storage.core.semantic.CoreService;
 import com.bobo.storage.core.semantic.Create;
 import com.bobo.storage.core.semantic.DomainEntity;
+import com.bobo.storage.core.semantic.EntityService;
 import com.bobo.storage.core.semantic.Read;
 import com.bobo.storage.core.song.Song;
 import com.bobo.storage.core.song.SongService;
@@ -15,7 +16,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 @CoreService
-public class PlaylistSongService implements Create<PlaylistSong>, Read<PlaylistSong> {
+public class PlaylistSongService
+		implements EntityService<PlaylistSong>, Create<PlaylistSong>, Read<PlaylistSong> {
 
 	private static final Logger log = LoggerFactory.getLogger(PlaylistSongService.class);
 

--- a/core/src/main/java/com/bobo/storage/core/semantic/CoreService.java
+++ b/core/src/main/java/com/bobo/storage/core/semantic/CoreService.java
@@ -13,12 +13,8 @@ import org.springframework.stereotype.Service;
  *
  * <p>Marks the service layer of {@link com.bobo.storage.core}.
  *
- * @implSpec
- *     <p>Method definitions should be grouped by CRUD operation. Within each group, singular
- *     operations should be defined before batch operations. Method order and parameter lists should
- *     reflect the field order of the associated entity (see {@link DomainEntity}).
- *     <p>These classes may be aware of other layers or technical concerns, but must not depend on
- *     them.
+ * @implSpec These classes may be aware of other layers or technical concerns, but must not depend
+ *     on them.
  */
 @Service
 @Documented

--- a/core/src/main/java/com/bobo/storage/core/semantic/EntityRepository.java
+++ b/core/src/main/java/com/bobo/storage/core/semantic/EntityRepository.java
@@ -11,6 +11,9 @@ import org.springframework.data.repository.Repository;
  * <p>An {@link EntityRepository} controls access to persistent stores, and marks the resource layer
  * of {@link com.bobo.storage.core}.
  *
+ * <p>Only an {@link EntityService}, for the same {@link DomainEntity}, may declare a dependency on
+ * this {@link EntityRepository}.
+ *
  * @apiNote Instances of this repository should be treated as collective nouns representing their
  *     entity type. e.g.
  *     <pre>

--- a/core/src/main/java/com/bobo/storage/core/semantic/EntityRepository.java
+++ b/core/src/main/java/com/bobo/storage/core/semantic/EntityRepository.java
@@ -11,9 +11,6 @@ import org.springframework.data.repository.Repository;
  * <p>An {@link EntityRepository} controls access to persistent stores, and marks the resource layer
  * of {@link com.bobo.storage.core}.
  *
- * <p>Only an {@link EntityService}, for the same {@link DomainEntity}, may declare a dependency on
- * this {@link EntityRepository}.
- *
  * @apiNote Instances of this repository should be treated as collective nouns representing their
  *     entity type. e.g.
  *     <pre>
@@ -21,13 +18,16 @@ import org.springframework.data.repository.Repository;
  * </pre>
  *
  * @implSpec
- *     <p>Method definitions should be grouped by CRUD operation. Within each group, singular
- *     operations should be defined before batch operations. Method order and parameter lists should
- *     reflect the field order of the associated entity (see {@link DomainEntity}).
- *     <p>These classes may be aware of other layers or technical concerns, but must not depend on
- *     them.
- * @implNote Fundamentally, this interface is serving the same purpose as {@link Repository}, but
- *     for our system.
+ *     <ul>
+ *       <li>The access modifier for an {@link EntityRepository} must be default (package-private).
+ *           Only the {@link EntityService}, for the same {@link DomainEntity}, may declare a
+ *           dependency on the {@link EntityRepository}.
+ *       <li>Method definitions should be grouped by CRUD operation. Within each group, singular
+ *           operations should be defined before batch operations. Method order and parameter lists
+ *           should reflect the field order of the associated entity (see {@link DomainEntity}).
+ *       <li>These classes may be aware of other layers or technical concerns, but must not depend
+ *           on them.
+ *     </ul>
  */
 @NoRepositoryBean
 public interface EntityRepository<T extends TechnicalID<ID>, ID> extends Repository<T, ID> {

--- a/core/src/main/java/com/bobo/storage/core/semantic/EntityService.java
+++ b/core/src/main/java/com/bobo/storage/core/semantic/EntityService.java
@@ -1,0 +1,43 @@
+package com.bobo.storage.core.semantic;
+
+/**
+ * Represents the API for a collection of entities.
+ *
+ * <p>While a {@link DomainEntity} maintains its invariants at an object level, an {@link
+ * EntityService} maintains invariants at a system level, e.g a uniqueness constraint.
+ *
+ * <p>This interface serves to mark, and define the basic contract of an {@link EntityService}. It
+ * should be composed with {@link Create}, {@link Read}, as needed. An {@link EntityService} does
+ * not have to support all CRUD operations e.g.
+ *
+ * <pre>{@code
+ * @CoreService
+ * public class AppleService implements EntityService<Apple>, Read<Apple>{}
+ * }</pre>
+ *
+ * @apiNote Instances of this service should be treated as collective nouns representing their
+ *     entity type. e.g.
+ *     <pre>
+ *   {@code private final AppleService apples;}
+ * </pre>
+ *
+ * @implSpec
+ *     <ul>
+ *       <li>Is a part of the service layer of {@link com.bobo.storage.core}, and must be annotated
+ *           with {@link CoreService}.
+ *       <li>An {@link EntityService} is expected to be injected, and never constructed by
+ *           application code. It may only have a single, all-args constructor. The constructor must
+ *           have a default access modifier (package-private), to control construction. It cannot be
+ *           {@code private}, because the constructor must be visible for Spring to create the bean
+ *           for DI.
+ *       <li>Method definitions should be grouped by CRUD operation. Within each group, singular
+ *           operations should be defined before batch operations. Method order and parameter lists
+ *           should reflect the field order of the associated entity (see {@link DomainEntity}).
+ *     </ul>
+ *
+ * @param <T> the {@link DomainEntity} this service is representing as a collection. We capture
+ *     {@code T} to denote that an {@link EntityService} represents the API for a single {@link
+ *     DomainEntity} collection.
+ */
+@SuppressWarnings("unused") // T is used in documentation to describe the collection API
+public interface EntityService<T extends DomainEntity> {}

--- a/core/src/main/java/com/bobo/storage/core/song/LookupService.java
+++ b/core/src/main/java/com/bobo/storage/core/song/LookupService.java
@@ -37,7 +37,7 @@ public class LookupService {
 
 	private final PlaylistSongService playlistSongs;
 
-	public LookupService(WebClient webClient, SongService songs, PlaylistSongService playlistSongs) {
+	LookupService(WebClient webClient, SongService songs, PlaylistSongService playlistSongs) {
 		this.webClient = webClient;
 		this.songs = songs;
 		this.playlistSongs = playlistSongs;

--- a/core/src/main/java/com/bobo/storage/core/song/SongRepository.java
+++ b/core/src/main/java/com/bobo/storage/core/song/SongRepository.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Repository;
  * @implSpec {@link EntityRepository}
  */
 @Repository
-public interface SongRepository
-		extends EntityRepository<Song, Integer>, CrudRepository<Song, Integer> {
+interface SongRepository extends EntityRepository<Song, Integer>, CrudRepository<Song, Integer> {
 
 	Optional<Song> findByUrl(String url);
 

--- a/core/src/main/java/com/bobo/storage/core/song/SongService.java
+++ b/core/src/main/java/com/bobo/storage/core/song/SongService.java
@@ -14,7 +14,7 @@ public class SongService implements Create<Song>, Read<Song> {
 
 	private final SongRepository songs;
 
-	public SongService(SongRepository songs) {
+	SongService(SongRepository songs) {
 		this.songs = songs;
 	}
 

--- a/core/src/main/java/com/bobo/storage/core/song/SongService.java
+++ b/core/src/main/java/com/bobo/storage/core/song/SongService.java
@@ -3,6 +3,7 @@ package com.bobo.storage.core.song;
 import com.bobo.storage.core.semantic.CoreService;
 import com.bobo.storage.core.semantic.Create;
 import com.bobo.storage.core.semantic.DomainEntity;
+import com.bobo.storage.core.semantic.EntityService;
 import com.bobo.storage.core.semantic.Read;
 import java.util.Collection;
 import java.util.Objects;
@@ -10,7 +11,7 @@ import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 
 @CoreService
-public class SongService implements Create<Song>, Read<Song> {
+public class SongService implements EntityService<Song>, Create<Song>, Read<Song> {
 
 	private final SongRepository songs;
 

--- a/core/src/test/java/com/bobo/storage/core/playlist/PlaylistTestRepository.java
+++ b/core/src/test/java/com/bobo/storage/core/playlist/PlaylistTestRepository.java
@@ -1,0 +1,8 @@
+package com.bobo.storage.core.playlist;
+
+import com.bobo.storage.core.semantic.EntityTestRepository;
+
+/**
+ * @implSpec {@link EntityTestRepository}
+ */
+public interface PlaylistTestRepository extends EntityTestRepository<Playlist> {}

--- a/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongRepositoryIT.java
+++ b/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongRepositoryIT.java
@@ -3,10 +3,10 @@ package com.bobo.storage.core.playlist.song;
 import com.bobo.semantic.IntegrationTest;
 import com.bobo.storage.core.playlist.Playlist;
 import com.bobo.storage.core.playlist.PlaylistMother;
-import com.bobo.storage.core.playlist.PlaylistRepository;
+import com.bobo.storage.core.playlist.PlaylistTestRepository;
 import com.bobo.storage.core.song.Song;
 import com.bobo.storage.core.song.SongMother;
-import com.bobo.storage.core.song.SongRepository;
+import com.bobo.storage.core.song.SongTestRepository;
 import java.util.Collection;
 import java.util.Random;
 import org.junit.jupiter.api.Assertions;
@@ -23,9 +23,9 @@ class PlaylistSongRepositoryIT {
 
 	private final Random random = new Random();
 
-	private final PlaylistRepository playlistRepository;
+	private final PlaylistTestRepository playlistRepository;
 
-	private final SongRepository songRepository;
+	private final SongTestRepository songRepository;
 
 	// Test Targets
 
@@ -34,8 +34,8 @@ class PlaylistSongRepositoryIT {
 	@Autowired
 	PlaylistSongRepositoryIT(
 			PlaylistSongRepository repository,
-			PlaylistRepository playlistRepository,
-			SongRepository songRepository) {
+			PlaylistTestRepository playlistRepository,
+			SongTestRepository songRepository) {
 		this.repository = repository;
 		this.playlistRepository = playlistRepository;
 		this.songRepository = songRepository;

--- a/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongServiceTest.java
+++ b/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongServiceTest.java
@@ -1,14 +1,21 @@
 package com.bobo.storage.core.playlist.song;
 
-import static org.mockito.Mockito.mock;
-
 import com.bobo.semantic.UnitTest;
 import com.bobo.storage.core.song.SongService;
 import java.util.Random;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest(PlaylistSongService.class)
+@ExtendWith(MockitoExtension.class)
 class PlaylistSongServiceTest {
+
+	@Mock private PlaylistSongRepository playlistSongs;
+
+	@Mock private SongService songs;
 
 	// Test Utilities
 
@@ -16,13 +23,7 @@ class PlaylistSongServiceTest {
 
 	// Test Targets
 
-	private PlaylistSongService service;
-
-	@BeforeEach
-	void setUp() {
-		PlaylistSongRepository repository = mock(PlaylistSongRepository.class);
-		service = new PlaylistSongService(repository, mock(SongService.class));
-	}
+	@InjectMocks private PlaylistSongService service;
 
 	/**
 	 * @see PlaylistSongService#add(PlaylistSong)

--- a/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongTestRepository.java
+++ b/core/src/test/java/com/bobo/storage/core/playlist/song/PlaylistSongTestRepository.java
@@ -1,0 +1,8 @@
+package com.bobo.storage.core.playlist.song;
+
+import com.bobo.storage.core.semantic.EntityTestRepository;
+
+/**
+ * @implSpec {@link EntityTestRepository}
+ */
+public interface PlaylistSongTestRepository extends EntityTestRepository<PlaylistSong> {}

--- a/core/src/test/java/com/bobo/storage/core/semantic/EntityTestRepository.java
+++ b/core/src/test/java/com/bobo/storage/core/semantic/EntityTestRepository.java
@@ -1,0 +1,16 @@
+package com.bobo.storage.core.semantic;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+/**
+ * A test accessible {@link EntityRepository}.
+ *
+ * <p>Used in repository slice tests that tests entities that require other entities to be present.
+ * The alternative is to spin up an application context and go through the services, which is too
+ * heavy-handed and is counter to what we use the slice test for.
+ *
+ * @param <T>
+ */
+@NoRepositoryBean
+public interface EntityTestRepository<T extends DomainEntity> extends CrudRepository<T, Integer> {}

--- a/core/src/test/java/com/bobo/storage/core/song/SongServiceTest.java
+++ b/core/src/test/java/com/bobo/storage/core/song/SongServiceTest.java
@@ -8,13 +8,15 @@ import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest(SongService.class)
 @ExtendWith(MockitoExtension.class)
 class SongServiceTest {
 
-	private SongRepository repository;
+	@Mock private SongRepository repository;
 
 	// Test Utilities
 
@@ -22,13 +24,7 @@ class SongServiceTest {
 
 	// Test Targets
 
-	private SongService service;
-
-	@BeforeEach
-	void setUp() {
-		repository = mock(SongRepository.class);
-		service = new SongService(repository);
-	}
+	@InjectMocks private SongService service;
 
 	/**
 	 * @see SongService#add(Song)

--- a/core/src/test/java/com/bobo/storage/core/song/SongTestRepository.java
+++ b/core/src/test/java/com/bobo/storage/core/song/SongTestRepository.java
@@ -1,0 +1,8 @@
+package com.bobo.storage.core.song;
+
+import com.bobo.storage.core.semantic.EntityTestRepository;
+
+/**
+ * @implSpec {@link EntityTestRepository}
+ */
+public interface SongTestRepository extends EntityTestRepository<Song> {}


### PR DESCRIPTION
As a benefit of moving to domain-based packaging, we can now enforce some architectural rules in code, not just conventions. 

While a DomainEntity maintains invariants at the object level, and an EntityService enforces invariants at the system level (e.g., a uniqueness constraint), an EntityRepository controls access to persistent storage for that entity. Repositories are strictly for use by their corresponding EntityService — no other service, and especially no other layer, should reference them directly.

Because services are now package mates with their repositories, we can safely mark those repositories as package-private and enforce this rule in code.

[revisions]
- mark *Service constructors package-private. Spring will use reflection to instantiate them. They should never be constructed in application code, but injected in. We can enforce this rule with access modifiers.

[additions]
- defined EntityService.
- defined EntityTestRepository. This is needed in repository slice tests that require other entities to be present in the database, for example, PlaylistSong testing requiring a Playlist and a Song. Because we have marked the source repositories package-private, the PlaylistSong repository test can no longer reference Playlist or Song repositories. To solve this issue, we simply define a test repository that exposes CRUD access for test setup.

[housekeeping] 
- prefer Mock, InjectMock annotations for setting up UnitTests.