### PR TITLE
added UnitTest, IntegrationTest tags

### DIFF
--- a/.scripts/pre-commit.sh
+++ b/.scripts/pre-commit.sh
@@ -55,7 +55,7 @@ if [ -n "$staged_src_files" ]; then
   EXIT_CODE=$?
   if [ "$EXIT_CODE" -ne 0 ]; then
     printf '\033[0;31m%s\033[0m' "Failed!"
-    printf '%s\n' " - There are Smoke test failures; the build is unstable. Resolve and restage."
+    printf '%s\n' " - There are Unit-Test failures; the build is unstable. Resolve and restage."
     printf '\n\033[0;31m'
     printf '%s\n' "$STDOUT" | grep "\[ERROR\]"
     printf '\033[0m\n'

--- a/.scripts/pre-commit.sh
+++ b/.scripts/pre-commit.sh
@@ -46,12 +46,12 @@ if [ "$EXIT_CODE" -ne 0 ]; then
 fi
 printf '\033[0;32m%s\033[0m\n' "Passed."
 # ========================================
-# Smoke-Test Check
+# Unit-Test Check
 # ========================================
 staged_src_files=$(git diff --cached --name-only | grep '\.java$')
 if [ -n "$staged_src_files" ]; then
-  printf "[\033[0;33m%s\033[0m] Checking... " "Smoke-Test"
-  STDOUT=$($MVN test -Dgroups="smoke")
+  printf "[\033[0;33m%s\033[0m] Checking... " "Unit-Test"
+  STDOUT=$($MVN test -Dgroups="unit")
   EXIT_CODE=$?
   if [ "$EXIT_CODE" -ne 0 ]; then
     printf '\033[0;31m%s\033[0m' "Failed!"

--- a/.scripts/pre-push.sh
+++ b/.scripts/pre-push.sh
@@ -28,7 +28,22 @@ Stash or stage the changes."
 fi
 printf '\033[0;32m%s\033[0m\n' "Passed."
 # ========================================
-# Integration Test Check
+# Smoke-Test Check
+# ========================================
+printf "[\033[0;33m%s\033[0m] Checking... " "Smoke-Test"
+STDOUT=$($MVN test -Dgroups="smoke")
+EXIT_CODE=$?
+if [ "$EXIT_CODE" -ne 0 ]; then
+  printf '\033[0;31m%s\033[0m' "Failed!"
+  printf '%s\n' " - There are test failures. Resolve and restage."
+  printf '\n\033[0;31m'
+  printf '%s\n' "$STDOUT" | grep "\[ERROR\]"
+  printf '\033[0m\n'
+  exit 1
+fi
+printf '\033[0;32m%s\033[0m\n' "Passed."
+# ========================================
+# Integration-Test Check
 # ========================================
 printf "[\033[0;33m%s\033[0m] Checking... " "Integration-Test"
 STDOUT=$($MVN verify)

--- a/.scripts/pre-push.sh
+++ b/.scripts/pre-push.sh
@@ -35,22 +35,7 @@ STDOUT=$($MVN test -Dgroups="smoke")
 EXIT_CODE=$?
 if [ "$EXIT_CODE" -ne 0 ]; then
   printf '\033[0;31m%s\033[0m' "Failed!"
-  printf '%s\n' " - There are test failures. Resolve and restage."
-  printf '\n\033[0;31m'
-  printf '%s\n' "$STDOUT" | grep "\[ERROR\]"
-  printf '\033[0m\n'
-  exit 1
-fi
-printf '\033[0;32m%s\033[0m\n' "Passed."
-# ========================================
-# Integration-Test Check
-# ========================================
-printf "[\033[0;33m%s\033[0m] Checking... " "Integration-Test"
-STDOUT=$($MVN verify)
-EXIT_CODE=$?
-if [ "$EXIT_CODE" -ne 0 ]; then
-  printf '\033[0;31m%s\033[0m' "Failed!"
-  printf '%s\n' " - There are test failures. Resolve and restage."
+  printf '%s\n' " - There are Smoke-Test failures; the build is unstable. Resolve and restage."
   printf '\n\033[0;31m'
   printf '%s\n' "$STDOUT" | grep "\[ERROR\]"
   printf '\033[0m\n'

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ rm-java:	## remove all Java artifacts produced by this script
 # Java Aliases
 # ========================================
 
+test-unit:	## run all unit tests (semantic.UnitTest)
+	$(MVN) test -Dgroups="unit"
+
 test-smoke:	## run all smoke tests (semantic.SmokeTest)
 	$(MVN) test -Dgroups="smoke"
 

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,13 @@ test-unit:	## run all unit tests (semantic.UnitTest)
 test-smoke:	## run all smoke tests (semantic.SmokeTest)
 	$(MVN) test -Dgroups="smoke"
 
-test-integration:	## run all integration tests (semantic.IntegrationTest)
-	$(MVN) verify -Dgroups="integration"
+test-integration:	## run all integration tests (semantic.IntegrationTest), excluding external system tests (test-integration-ext)
+	$(MVN) verify -Dgroups="integration" -DexcludedGroups="external"
 
-.PHONY: test-unit test-smoke test-integration
+test-integration-ext:	## run all external integration tests (semantic.IntegrationTest#EXTERNAL)
+	$(MVN) verify -Dgroups="external"
+
+.PHONY: test-unit test-smoke test-integration test-integration-ext
 # ========================================
 # Docker Artifacts
 # ========================================
@@ -138,7 +141,7 @@ help:  ## show available targets
 		| awk 'BEGIN {FS = ":.*?## "}; { \
 			cmd = $$1; desc = $$2; \
 			gsub(/\(([^)]*)\)/, "\033[34m&\033[0m", desc); \
-			printf "  \033[36m%-15s\033[0m %s\n", cmd, desc \
+			printf "  \033[36m%-21s\033[0m %s\n", cmd, desc \
 		}'
 	@printf "%s\n" \
 	"------------------"

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ test-unit:	## run all unit tests (semantic.UnitTest)
 test-smoke:	## run all smoke tests (semantic.SmokeTest)
 	$(MVN) test -Dgroups="smoke"
 
-.PHONY: test-smoke
+test-integration:	## run all integration tests (semantic.IntegrationTest)
+	$(MVN) verify -Dgroups="integration"
+
+.PHONY: test-unit test-smoke test-integration
 # ========================================
 # Docker Artifacts
 # ========================================

--- a/core/src/test/java/com/bobo/storage/core/domain/DomainEntityTest.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/DomainEntityTest.java
@@ -1,5 +1,6 @@
 package com.bobo.storage.core.domain;
 
+import com.bobo.semantic.UnitTest;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@UnitTest(DomainEntity.class)
 class DomainEntityTest {
 
 	/**

--- a/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
@@ -12,9 +12,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /** Testing Integration with OEmbed Providers. */
-@ContextConfiguration(classes = {WebClientAutoConfiguration.class})
+@IntegrationTest({Provider.class, WebClient.class})
 @ExtendWith(SpringExtension.class)
-@IntegrationTest(Provider.class)
+@ContextConfiguration(classes = {WebClientAutoConfiguration.class})
 class ProviderIT {
 
 	private final WebClient client;

--- a/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/ProviderIT.java
@@ -2,6 +2,7 @@ package com.bobo.storage.core.domain;
 
 import com.bobo.semantic.IntegrationTest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 /** Testing Integration with OEmbed Providers. */
 @IntegrationTest({Provider.class, WebClient.class})
+@Tag(IntegrationTest.EXTERNAL_TAG)
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {WebClientAutoConfiguration.class})
 class ProviderIT {

--- a/core/src/test/java/com/bobo/storage/core/domain/SongIT.java
+++ b/core/src/test/java/com/bobo/storage/core/domain/SongIT.java
@@ -4,6 +4,7 @@ import com.bobo.semantic.IntegrationTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * work as expected in the wild.
  */
 @IntegrationTest({Song.class, WebClient.class})
+@Tag(IntegrationTest.EXTERNAL_TAG)
 class SongIT {
 
 	private final WebClient client;

--- a/core/src/test/java/com/bobo/storage/core/resource/query/PlaylistRepositoryIT.java
+++ b/core/src/test/java/com/bobo/storage/core/resource/query/PlaylistRepositoryIT.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.CrudRepository;
 
+@IntegrationTest({PlaylistRepository.class, CrudRepository.class})
 @DataJpaTest
-@IntegrationTest({PlaylistRepository.class, Repository.class})
 class PlaylistRepositoryIT {
 
 	private final PlaylistRepository repository;

--- a/core/src/test/java/com/bobo/storage/core/resource/query/PlaylistSongRepositoryIT.java
+++ b/core/src/test/java/com/bobo/storage/core/resource/query/PlaylistSongRepositoryIT.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.CrudRepository;
 
+@IntegrationTest({PlaylistSongRepository.class, CrudRepository.class})
 @DataJpaTest
-@IntegrationTest({PlaylistSongRepository.class, Repository.class})
 class PlaylistSongRepositoryIT {
 
 	// Test Utilities

--- a/core/src/test/java/com/bobo/storage/core/resource/query/SongRepositoryIT.java
+++ b/core/src/test/java/com/bobo/storage/core/resource/query/SongRepositoryIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.CrudRepository;
 
 /**
  * These tests are specifically for repository methods I define using the query language. I do not
@@ -19,8 +19,8 @@ import org.springframework.data.repository.Repository;
  * <p>They probably would only be necessary to re-run if I change the domain model, otherwise they
  * can be skipped. TODO Figure out if I could define a test suite?
  */
+@IntegrationTest({SongRepository.class, CrudRepository.class})
 @DataJpaTest
-@IntegrationTest({SongRepository.class, Repository.class})
 class SongRepositoryIT {
 
 	// Test Utilities

--- a/core/src/test/java/com/bobo/storage/core/service/impl/SongServiceImplTest.java
+++ b/core/src/test/java/com/bobo/storage/core/service/impl/SongServiceImplTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 @UnitTest(SongServiceImpl.class)
+@ExtendWith(MockitoExtension.class)
 class SongServiceImplTest {
 
 	private SongRepository repository;

--- a/semantic/src/test/java/com/bobo/semantic/IntegrationTest.java
+++ b/semantic/src/test/java/com/bobo/semantic/IntegrationTest.java
@@ -55,4 +55,31 @@ public @interface IntegrationTest {
 	 *     to it directly.
 	 */
 	String TAG = "integration";
+
+	/**
+	 * The {@link Tag} value to use for {@link IntegrationTest} tests that interact with external
+	 * systems.
+	 *
+	 * <p>We make a distinct because we cannot guarantee the status, or behaviour, of a system we do
+	 * not control, which makes these tests potentially "flaky".
+	 *
+	 * <p>These are tests we might run as part of a health check, but not in a CI/CD pipeline, or
+	 * local workflow.
+	 *
+	 * <p>Tagging via JUnit enables running a slice of tests via Maven.
+	 *
+	 * <pre>{@code
+	 * mvn verify -Dgroups="external"
+	 * }</pre>
+	 *
+	 * <p>Tagging also enables the exclusion of specific tests. Exclusion takes precedence; if a test
+	 * is both included and excluded via tags (tests can have multiple tags), it will be excluded.
+	 *
+	 * <pre>{@code
+	 * mvn verify -Dgroups="integration" -DexcludedGroups="external"
+	 * }</pre>
+	 *
+	 * @see Tags
+	 */
+	String EXTERNAL_TAG = "external";
 }

--- a/semantic/src/test/java/com/bobo/semantic/IntegrationTest.java
+++ b/semantic/src/test/java/com/bobo/semantic/IntegrationTest.java
@@ -1,6 +1,58 @@
 package com.bobo.semantic;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+
+/**
+ * A test that verifies the interaction between one or more components.
+ *
+ * <p>Typically, to verify the interaction between our components and third-party libraries or
+ * systems. They can also be used to test assumptions about third-party components, and fail if
+ * those assumptions our system relies on fail.
+ *
+ * <p>An {@link IntegrationTest} can also be used to verify our components work together correctly,
+ * but as far as possible prefer defining strong contracts for our components and {@link UnitTest}
+ * expected behaviour against those contracts.
+ *
+ * <p>An {@link IntegrationTest} may still mock or stub out components as needed, and this is
+ * encouraged to narrow the scope of what is under test.
+ *
+ * <p>The nature of these tests makes them slower, as they may need to spin up the application
+ * context, or a portion thereof. They are expected to be run before merging or releasing to confirm
+ * we have not regressed, and should be run anytime dependencies are updated or changed.
+ *
+ * @implSpec Suffix test classes with {@code IT}, which is the default pattern the Maven Failsafe
+ *     plugin uses to detect integration tests for the verification cycle ({@code mvn verify}).
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(IntegrationTest.TAG)
 public @interface IntegrationTest {
 
+	/**
+	 * @return the component classes being tested.
+	 */
 	Class<?>[] value() default {};
+
+	/**
+	 * The {@link Tag} value to use for {@link IntegrationTest}.
+	 *
+	 * <p>Tagging via JUnit enables running a slice of tests via Maven.
+	 *
+	 * <pre>{@code
+	 * mvn verify -Dgroups="integration"
+	 * }</pre>
+	 *
+	 * @see Tags
+	 * @apiNote Annotating a test class with {@link IntegrationTest} will automatically apply this
+	 *     tag. This {@code TAG} constant is available for special cases where you may want to refer
+	 *     to it directly.
+	 */
+	String TAG = "integration";
 }

--- a/semantic/src/test/java/com/bobo/semantic/UnitTest.java
+++ b/semantic/src/test/java/com/bobo/semantic/UnitTest.java
@@ -1,6 +1,46 @@
 package com.bobo.semantic;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+
+/**
+ * A test that verifies the expected behaviour of an isolated "unit" of code.
+ *
+ * <p>Typically at tests the contract of {@code public} methods. The contract is what has been
+ * defined by the method signature, and the words in its documentation.
+ *
+ * @implSpec Suffix test classes with {@code Test}, which is the default pattern Maven surefire uses
+ *     to detect unit tests for the test cycle ({@code mvn test}).
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(UnitTest.TAG)
 public @interface UnitTest {
 
+	/**
+	 * @return the class whose behaviour is being verified by this {@link UnitTest}.
+	 */
 	Class<?> value() default Object.class;
+
+	/**
+	 * The {@link Tag} value to use for {@link UnitTest}.
+	 *
+	 * <p>Tagging via JUnit enables running a slice of tests via Maven.
+	 *
+	 * <pre>{@code
+	 * mvn test -Dgroups="unit"
+	 * }</pre>
+	 *
+	 * @see Tags
+	 * @apiNote Annotating a test class with {@link UnitTest} will automatically apply this tag. This
+	 *     {@code TAG} constant is available for special cases where you may want to refer to it
+	 *     directly.
+	 */
+	String TAG = "unit";
 }

--- a/semantic/src/test/java/com/bobo/semantic/UnitTest.java
+++ b/semantic/src/test/java/com/bobo/semantic/UnitTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Tags;
  * <p>Typically at tests the contract of {@code public} methods. The contract is what has been
  * defined by the method signature, and the words in its documentation.
  *
- * @implSpec Suffix test classes with {@code Test}, which is the default pattern Maven surefire uses
- *     to detect unit tests for the test cycle ({@code mvn test}).
+ * @implSpec Suffix test classes with {@code Test}, which is the default pattern the Maven Surefire
+ *     plugin uses to detect unit tests for the test cycle ({@code mvn test}).
  */
 @Documented
 @Target(ElementType.TYPE)

--- a/web/src/test/java/com/bobo/storage/web/api/request/RequestIT.java
+++ b/web/src/test/java/com/bobo/storage/web/api/request/RequestIT.java
@@ -18,9 +18,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Tests that {@code Request(s)} are mapped as I expect by the Jackson {@link ObjectMapper}, when
  * using the (default) autoconfiguration provided by Spring.
  */
-@ContextConfiguration(classes = {JacksonAutoConfiguration.class})
-@ExtendWith(SpringExtension.class)
 @IntegrationTest({ObjectMapper.class, JacksonAutoConfiguration.class})
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {JacksonAutoConfiguration.class})
 class RequestIT {
 
 	private final ObjectMapper mapper;

--- a/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistSongsControllerIT.java
+++ b/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistSongsControllerIT.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.bobo.semantic.UnitTest;
+import com.bobo.semantic.IntegrationTest;
 import com.bobo.storage.core.domain.*;
 import com.bobo.storage.core.service.PlaylistService;
 import com.bobo.storage.core.service.PlaylistSongService;
@@ -19,21 +19,19 @@ import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@TestInstance(
-		TestInstance.Lifecycle
-				.PER_CLASS) // TODO rm. Does not give the benefits I assumed. We don't need shared state.
+@IntegrationTest({
+	PlaylistSongsController.class,
+	ObjectMapper.class,
+	ControllerExceptionHandler.class
+})
 @WebMvcTest(PlaylistSongsController.class)
-@UnitTest(
-		PlaylistSongsController
-				.class) // In Spring, this is a Slice test, but that concept isn't universal - I think.
-class PlaylistSongsControllerTest {
+class PlaylistSongsControllerIT {
 
 	// Mock Dependencies
 
@@ -56,7 +54,7 @@ class PlaylistSongsControllerTest {
 	private final Random random = new Random();
 
 	@Autowired
-	PlaylistSongsControllerTest(MockMvc mvc, ObjectMapper mapper) {
+	PlaylistSongsControllerIT(MockMvc mvc, ObjectMapper mapper) {
 		this.mvc = mvc;
 		this.mapper = mapper;
 	}

--- a/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistsControllerIT.java
+++ b/web/src/test/java/com/bobo/storage/web/api/v2/controller/PlaylistsControllerIT.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.bobo.semantic.UnitTest;
+import com.bobo.semantic.IntegrationTest;
 import com.bobo.storage.core.domain.EntityMother;
 import com.bobo.storage.core.domain.Playlist;
 import com.bobo.storage.core.domain.PlaylistMother;
@@ -30,10 +30,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@IntegrationTest({PlaylistsController.class, ObjectMapper.class, ControllerExceptionHandler.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WebMvcTest(PlaylistsController.class)
-@UnitTest(PlaylistsController.class)
-class PlaylistsControllerTest {
+class PlaylistsControllerIT {
 
 	// Mock Dependencies
 
@@ -54,7 +54,7 @@ class PlaylistsControllerTest {
 	private final Random random = new Random();
 
 	@Autowired
-	PlaylistsControllerTest(MockMvc mvc, ObjectMapper mapper) {
+	PlaylistsControllerIT(MockMvc mvc, ObjectMapper mapper) {
 		this.mvc = mvc;
 		this.mapper = mapper;
 	}


### PR DESCRIPTION
Added definitions, in the style of SmokeTest, to UnitTest and IntegrationTest semantic annotations. These tests are tagged as well, with corresponding alias rules provided in the Makefile.

Being able to control the slice of tests being run is already extremely useful. I believe this will pay dividends as the system grows.

[fixes]
- missing UnitTest annotation on DomainEntityTest.

[revisions]
- mv *ControllerTest *ControllerIT. They are slice tests spinning up partial context.
- revert pre-commit hook; add back UnitTest check.
- mv SmokeTest check to pre-push hook; rm IntegrationTest check. Perhaps in a later iteration we can run the Integration tests are a pre/post merge hook, if that is possible.

[housekeeping]
- amend `make help` command "column" width to fit new rule target.